### PR TITLE
add aux file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+paper
+__pycache__

--- a/visualizer.py
+++ b/visualizer.py
@@ -143,8 +143,11 @@ def build_graph(theorems, option_show_label, option_existing_theorems_only):
 
     for t in theorems:
         if t['used']:
-            label_text = ' = ' + t['latex_label'] if (t['show_label'] and option_show_label) else ''
-            G.node(t['latex_label'],t['number'] + label_text)
+            if t['show_label'] and option_show_label:
+                label_text = t['latex_label']
+            else:
+                label_text = t['number']
+            G.node(t['latex_label'], label_text)
 
     return G
 


### PR DESCRIPTION
Using aux file can translate the label to its displayed text, which gave more insights.

Some articles do not follow "section dot subsection" numbering convention and it is useful to extract the displayed text in such case.

Below is the screenshot of running on [this article](https://arxiv.org/abs/2004.05944) (with aux support):
![main gv](https://user-images.githubusercontent.com/23316477/94507044-7260ac00-0241-11eb-9db1-1fcb85d2644a.png)
